### PR TITLE
feat: Init cluster scope resources

### DIFF
--- a/cluster-scope/base/core/namespaces/ingress/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/ingress/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/ingress/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/ingress/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: ingress

--- a/cluster-scope/base/core/namespaces/platform-mq/kustomization.yaml
+++ b/cluster-scope/base/core/namespaces/platform-mq/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/cluster-scope/base/core/namespaces/platform-mq/namespace.yaml
+++ b/cluster-scope/base/core/namespaces/platform-mq/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: platform-mq

--- a/cluster-scope/overlays/dev/kustomization.yaml
+++ b/cluster-scope/overlays/dev/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/core/namespaces/ingress
+- ../../base/core/namespaces/platform-mq

--- a/cluster-scope/overlays/operate-first/README.md
+++ b/cluster-scope/overlays/operate-first/README.md
@@ -1,0 +1,5 @@
+# Operate First Community Cloud environment
+
+Operate First manages all resources which require elevated permissions to be managed through [`operate-first/apps` repository via their `cluster-scope` folder](https://github.com/operate-first/apps/tree/master/cluster-scope).
+
+Please follow instructions at https://www.operate-first.cloud/hitchhikers-guide/apps/docs/cluster-scope/onboarding_to_cluster.md


### PR DESCRIPTION
An attempt to track cluster scope resources for dev purposes in here. Treat operate-first as an overlay of this and redirect users to operate-first/apps for changes there.