### PR TITLE
Kafka discovery

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
       - id: trailing-whitespace

--- a/platform-mq/base/kafka.yaml
+++ b/platform-mq/base/kafka.yaml
@@ -5,15 +5,15 @@ metadata:
 spec:
   kafka:
     config:
-      offsets.topic.replication.factor: 3
-      transaction.state.log.replication.factor: 3
-      transaction.state.log.min.isr: 2
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
       log.message.format.version: "2.7"
       inter.broker.protocol.version: "2.7"
     version: 2.7.0
     storage:
       type: ephemeral
-    replicas: 3
+    replicas: 1
     listeners:
       - name: plain
         port: 9092
@@ -29,4 +29,4 @@ spec:
   zookeeper:
     storage:
       type: ephemeral
-    replicas: 3
+    replicas: 1

--- a/platform-mq/components/kafka-ui/deployment.yaml
+++ b/platform-mq/components/kafka-ui/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-ui
+  labels:
+    app: kafka-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-ui
+  template:
+    metadata:
+      labels:
+        app: kafka-ui
+    spec:
+      containers:
+        - name: kafka-ui
+          image: "docker.io/provectuslabs/kafka-ui:latest"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: KAFKA_CLUSTERS_0_NAME
+              value: kafka
+            - name: KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS
+              value: kafka-kafka-bootstrap:9092
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10

--- a/platform-mq/components/kafka-ui/kustomization.yaml
+++ b/platform-mq/components/kafka-ui/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - deployment.yaml
+  - service.yaml
+  - route.yaml

--- a/platform-mq/components/kafka-ui/route.yaml
+++ b/platform-mq/components/kafka-ui/route.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kafka-ui
+spec:
+  to:
+    kind: Service
+    name: kafka-ui
+  port:
+    targetPort: http

--- a/platform-mq/components/kafka-ui/service.yaml
+++ b/platform-mq/components/kafka-ui/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-ui
+  labels:
+    app: kafka-ui
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: kafka-ui

--- a/platform-mq/overlays/dev/kustomization.yaml
+++ b/platform-mq/overlays/dev/kustomization.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: ingress
-resources:
-- ../../base

--- a/platform-mq/overlays/operate-first/kustomization.yaml
+++ b/platform-mq/overlays/operate-first/kustomization.yaml
@@ -4,3 +4,5 @@ kind: Kustomization
 namespace: seraph-platform-mq
 resources:
 - ../../base
+components:
+- ../../components/kafka-ui


### PR DESCRIPTION
For dev purposes let's scale kafka down a bit to a single replica cluster, treating it as a "dev env" for now.

Additionally deploy https://github.com/provectus/kafka-ui at http://kafka-ui-seraph-platform-mq.apps.smaug.na.operate-first.cloud for easier discovery for now (since we don't plan on implementing any UI in near future).